### PR TITLE
Support passing --signoff to git-commit (RT#57925)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for Dist::Zilla::Plugin::Git
 
 {{$NEXT}}
+  - added 'signoff' config option to cause Git::Commit to pass
+    --signoff to git-commit
+    (Sean Whitton, RT#57925)
 
 2.046     2019-03-17 01:16:52Z
   - added %V format code for the version number with the leading 'v'

--- a/corpus/commit-signoff/Changes
+++ b/corpus/commit-signoff/Changes
@@ -1,0 +1,6 @@
+Changes
+
+1.23 2009-11-16 19:15:45 CET
+ - foo
+ - bar
+ - baz

--- a/corpus/commit-signoff/dist.ini
+++ b/corpus/commit-signoff/dist.ini
@@ -1,0 +1,13 @@
+name    = Foo
+version = 1.23
+author  = foobar
+license = Perl_5
+abstract = Test Library
+copyright_holder = foobar
+copyright_year   = 2009
+
+[GatherDir]
+[FakeRelease]
+[MetaConfig]
+[Git::Commit]
+signoff = 1

--- a/lib/Dist/Zilla/Plugin/Git/Commit.pm
+++ b/lib/Dist/Zilla/Plugin/Git/Commit.pm
@@ -11,7 +11,7 @@ use namespace::autoclean;
 use File::Temp           qw{ tempfile };
 use Moose;
 use MooseX::Has::Sugar;
-use Types::Standard qw(Str ArrayRef);
+use Types::Standard qw(Str ArrayRef Bool);
 use Types::Path::Tiny 'Path';
 use Path::Tiny 0.048 qw(); # subsumes
 use Cwd;
@@ -30,6 +30,7 @@ sub _git_config_mapping { +{
 
 has commit_msg => ( ro, isa=>Str, default => 'v%V%n%n%c' );
 has add_files_in  => ( ro, isa=> ArrayRef[Path], coerce => 1, default => sub { [] });
+has signoff => ( ro, isa => Bool, default => 0 );
 
 
 # -- public methods
@@ -46,6 +47,7 @@ around dump_config => sub
     $config->{+__PACKAGE__} = {
         commit_msg => $self->commit_msg,
         add_files_in => [ sort @{ $self->add_files_in } ],
+        signoff => $self->signoff,
         blessed($self) ne __PACKAGE__ ? ( version => $VERSION ) : (),
     };
 
@@ -88,7 +90,8 @@ sub after_release {
 
     # commit the files in git
     $git->add( @output );
-    $self->log_debug($_) for $git->commit( { file=>$filename } );
+    $self->log_debug($_) for $git->commit( { signoff => $self->signoff,
+                                             file    => $filename } );
     $self->log("Committed @output");
 }
 

--- a/t/commit-signoff.t
+++ b/t/commit-signoff.t
@@ -16,7 +16,7 @@ my $homedir = clean_environment;
 
 # build fake repository
 my $zilla = Dist::Zilla::Tester->from_config({
-  dist_root => path('corpus/commit')->absolute,
+  dist_root => path('corpus/commit-signoff')->absolute,
 });
 
 {
@@ -30,9 +30,9 @@ my $zilla = Dist::Zilla::Tester->from_config({
 
   # check if dist.ini and changelog have been committed
   my ($log) = $git->log( 'HEAD' );
-  unlike( $log->message, qr/^Signed-off-by: /,
-          'commit message not signed off by default' );
-  like( $log->message, qr/v1.23\n[^a-z]*foo[^a-z]*bar[^a-z]*baz/, 'commit message taken from changelog' );
+  like( $log->message, qr/^Signed-off-by: /m, 'commit message signed off' );
+  like( $log->message, qr/v1.23\n[^a-z]*foo[^a-z]*bar[^a-z]*baz/,
+        'commit message taken from changelog' );
 }
 
 sub append_to_file {


### PR DESCRIPTION
Some projects require Signed-off-by: lines in git commit messages to certify the contents of [DEVELOPER-CERTIFICATE](https://developercertificate.org/) for contributions.  In my case I use a git pre-push hook which blocks pushing commits which have not been signed off.  That means I need the Git::Commit plugin to pass --signoff to git-commit in order to use that plugin for my projects.  Please consider applying this patch to enable that.  Thanks!