### PR TITLE
test util: ensure that branch is called 'master'

### DIFF
--- a/t/lib/Util.pm
+++ b/t/lib/Util.pm
@@ -176,6 +176,9 @@ sub init_repo
   #   The file will have its original line endings in your working directory.
   $git->config( 'core.autocrlf' => 'false' );
 
+  # Ensure the initial branch is called 'master'.
+  path("$git_dir/.git/HEAD")->spew("ref: refs/heads/master\n");
+
   if (@initial_files) {
     # Don't use --force, because only -f works before git 1.5.6
     $git->add(-f => @initial_files);


### PR DESCRIPTION
`git init` determines the name of the initial branch based on the
contents of .git/HEAD, which is copied in from a template directory,
which can be set in a number of ways. I happen to use a non-standard
layout, so all of these tests failed for me (because they assume a
'master' branch). This commit just fixes up the initial branch name to
be what we expect, regardless of any local template directory.