### PR TITLE
Fix bug: correct multivalue_args name

### DIFF
--- a/lib/Dist/Zilla/Plugin/Git/Init.pm
+++ b/lib/Dist/Zilla/Plugin/Git/Init.pm
@@ -63,7 +63,7 @@ has config_entries => (
   default => sub { [] },
 );
 
-sub mvp_multivalue_args { qw(config_entries remotes push_url) }
+sub mvp_multivalue_args { qw(config_entries remotes push_urls) }
 sub mvp_aliases { return { config => 'config_entries', remote => 'remotes', push_url => 'push_urls' } }
 
 sub after_mint {


### PR DESCRIPTION
Current behaviour causes the below error:

Attribute (push_urls) does not pass the type constraint because: Value "origin git\@github.com:mikkoi/%{lc}N.git" did not pass type constraint "ArrayRef[Str]" at constructor Dist::Zilla::Plugin::Git::Init::new (defined at
 [..]/Dist/Zilla/Plugin/Git/Init.pm
 line 123) line 106