### PR TITLE
clean XDG_CONFIG_HOME in tests

### DIFF
--- a/t/lib/Util.pm
+++ b/t/lib/Util.pm
@@ -100,6 +100,7 @@ sub _clean_environment
 
   $ENV{HOME} = $ENV{GNUPGHOME} = $homedir;
   $ENV{GIT_CONFIG_NOSYSTEM} = 1; # Don't read /etc/gitconfig
+  delete $ENV{XDG_CONFIG_HOME};
 } # end _clean_environment
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
The tests want a predictable environment and git configuration. They create a fake HOME to use for this. But a XDG_CONFIG_HOME variable could also interfere with this. Delete the environment variable in the tests to ensure a user config won't be used.